### PR TITLE
[PR] Hotfix: Remove force set headers that we specify elsewhere

### DIFF
--- a/wp-document-revisions.php
+++ b/wp-document-revisions.php
@@ -752,15 +752,15 @@ class Document_Revisions {
 		@header( 'Content-Disposition: ' . $disposition . '; filename="' . $filename . '"' );
 
 		//filetype and length
-		@header( 'Content-Type: ' . $mimetype ); // always send this
-		@header( 'Content-Length: ' . filesize( $file ) );
+		//@header( 'Content-Type: ' . $mimetype ); // always send this
+		//@header( 'Content-Length: ' . filesize( $file ) );
 
 		//modified
 		$last_modified = gmdate( 'D, d M Y H:i:s', filemtime( $file ) );
 		$etag = '"' . md5( $last_modified ) . '"';
 		@header( "Last-Modified: $last_modified GMT" );
 		@header( 'ETag: ' . $etag );
-		@header( 'Expires: ' . gmdate( 'D, d M Y H:i:s', time() + 100000000 ) . ' GMT' );
+		//@header( 'Expires: ' . gmdate( 'D, d M Y H:i:s', time() + 100000000 ) . ' GMT' );
 
 		// Support for Conditional GET
 		$client_etag = isset( $_SERVER['HTTP_IF_NONE_MATCH'] ) ? stripslashes( $_SERVER['HTTP_IF_NONE_MATCH'] ) : false;


### PR DESCRIPTION
The built in "Expires" header was set to several years in the future, which causes browsers (IE) to hold on to the PDF even when a newer version has been uploaded. I'm removing the "Expires" header completely but we may want to revisit a sane value in the future.

This is something that we should propose to change upstream and instead handle the serving of these headers in a way that is compatible with existing WordPress hooks.
