### PR TITLE
Verify a post ID has been passed before verifying post type

### DIFF
--- a/wp-document-revisions.php
+++ b/wp-document-revisions.php
@@ -1225,8 +1225,9 @@ class Document_Revisions extends HTTP_WebDAV_Server {
 	function filename_rewrite( $file ) {
 
 		//verify this is a document
-		if ( !$this->verify_post_type( $_POST['post_id'] ) )
+		if ( ! isset( $_POST['post_id'] ) || ! $this->verify_post_type( $_POST['post_id'] ) ) {
 			return $file;
+		}
 
 		//hash and replace filename, appending extension
 		$file['name'] = md5( $file['name'] .time() ) . $this->get_extension( $file['name'] );
@@ -1247,8 +1248,9 @@ class Document_Revisions extends HTTP_WebDAV_Server {
 	function rewrite_file_url( $file ) {
 
 		//verify that this is a document
-		if ( !$this->verify_post_type( $_POST['post_id'] ) )
+		if ( ! isset( $_POST['post_id'] ) || ! $this->verify_post_type( $_POST['post_id'] ) ) {
 			return $file;
+		}
 
 		$file['url'] = get_permalink( $_POST['post_id'] );
 


### PR DESCRIPTION
When a file is uploaded directly to the media library in grid view, rather than as an attachment, `$_POST['post_id']` is not available and will generate an error in the AJAX response. We can assume that if post ID is not available, this is not a document.

---

This is also a PR upstream https://github.com/benbalter/wp-document-revisions/pull/86
