### PR TITLE
[PR] Allow the plugin to issue content type headers for S3

### DIFF
--- a/wp-document-revisions.php
+++ b/wp-document-revisions.php
@@ -751,9 +751,12 @@ class Document_Revisions {
 		$disposition = ( apply_filters( 'document_content_disposition_inline', true ) ) ? 'inline' : 'attachment';
 		@header( 'Content-Disposition: ' . $disposition . '; filename="' . $filename . '"' );
 
-		//filetype and length
-		//@header( 'Content-Type: ' . $mimetype ); // always send this
-		//@header( 'Content-Length: ' . filesize( $file ) );
+		// Add content type and length headers if the file is being served via
+		// S3 stream. If not, then we allow the web server to set the permissions.
+		if ( 0 === strpos( $file, 's3://', 0 ) ) {
+			@header( 'Content-Type: ' . $mimetype );
+			@header( 'Content-Length: ' . filesize( $file ) );
+		}
 
 		//modified
 		$last_modified = gmdate( 'D, d M Y H:i:s', filemtime( $file ) );


### PR DESCRIPTION
PDFs were getting a text/html content type header when served
via an S3 stream. There's probably something more we should do
when working with S3 uploads, but the immediate solution is to
give control back to the plugin. This _may_ break things again
with PDFs in IE, but we'll see.
