### PR TITLE
[PR] Only cache revisions output if revisions exist

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ matrix:
     - php: 5.6
       env: WP_VERSION=latest
     - php: 5.3
+      dist: precise
       env: WP_VERSION=latest
     - php: 7.1
       env: WP_TRAVISCI=phpcs

--- a/includes/class-wp-document-revisions.php
+++ b/includes/class-wp-document-revisions.php
@@ -663,11 +663,15 @@ class WP_Document_Revisions {
 		);
 
 		$i = 1;
+
+		$output = array();
 		foreach ( $revs as $rev ) {
 			$output[ $i++ ] = $rev->ID;
 		}
 
-		wp_cache_set( $post_id, $output, 'document_revision_indices' );
+		if ( ! empty( $output ) ) {
+			wp_cache_set( $post_id, $output, 'document_revision_indices' );
+		}
 
 		return $output;
 


### PR DESCRIPTION
In some cases, and likely due to some other customization by another plugin, it's possible to generate a post save without entering a title or content and with no revision.

It appears that in these cases, the `get_revision_indices()` method attempts to cache an `$output` variable that doesn't exist. Shortly after, the `get_revision_number()` method attempts to `array_search()` on a piece of data that is not an array.

This change sets `$output` to an empty array and, if no data is stored in it, avoids storing it in cache and returns it as is.