### PR TITLE
Display empty excerpts when the_excerpt() and get_the_excerpt() are used.

### DIFF
--- a/includes/class-wp-document-revisions.php
+++ b/includes/class-wp-document-revisions.php
@@ -98,8 +98,7 @@ class WP_Document_Revisions {
 		add_action( 'init', array( &$this, 'edit_flow_support' ), 11 );
 		add_action( 'init', array( &$this, 'use_workflow_states' ), 50 );
 
-		// WSU Hotfix: Revision comments are stored as excerpts and should not be output with the_excerpt() by default.
-		add_filter( 'get_the_excerpt', '__return_empty_string' );
+		add_filter( 'get_the_excerpt', array( $this, 'empty_excerpt_return' ), 10, 2 );
 
 		// load front-end features (shortcode, widgets, etc.)
 		include dirname( __FILE__ ) . '/class-wp-document-revisions-front-end.php';
@@ -1887,6 +1886,22 @@ class WP_Document_Revisions {
 
 	}
 
+	/**
+	 * Return an empty excerpt for documents on front end views to avoid leaking
+	 * revision notes.
+	 *
+	 * @param string  $excerpt
+	 * @param WP_Post $post
+	 *
+	 * @return string
+	 */
+	public function empty_excerpt_return( $excerpt, $post ) {
+		if ( 'document' === $post->post_type && ! is_admin() ) {
+			return '';
+		}
+
+		return $excerpt;
+	}
 
 	/**
 	 * Remove nocache headers from document downloads on IE < 8

--- a/includes/class-wp-document-revisions.php
+++ b/includes/class-wp-document-revisions.php
@@ -98,6 +98,9 @@ class WP_Document_Revisions {
 		add_action( 'init', array( &$this, 'edit_flow_support' ), 11 );
 		add_action( 'init', array( &$this, 'use_workflow_states' ), 50 );
 
+		// Revision comments are stored as excerpts and should not be output with the_excerpt() by default.
+		add_filter( 'get_the_excerpt', '__return_empty_string' );
+
 		// load front-end features (shortcode, widgets, etc.)
 		include dirname( __FILE__ ) . '/class-wp-document-revisions-front-end.php';
 		new WP_Document_Revisions_Front_End( $this );

--- a/includes/class-wp-document-revisions.php
+++ b/includes/class-wp-document-revisions.php
@@ -856,9 +856,11 @@ class WP_Document_Revisions {
 		@header( "Last-Modified: $last_modified GMT" );
 		@header( 'ETag: ' . $etag );
 
-		// WSU Hotfix
-		// See https://github.com/washingtonstateuniversity/wp-document-revisions/pull/2
-		// @header( 'Expires: ' . gmdate( 'D, d M Y H:i:s', time() + 100000000 ) . ' GMT' );
+		/*
+		 * WSU Hotfix
+		 * See https://github.com/washingtonstateuniversity/wp-document-revisions/pull/2
+		 * @header( 'Expires: ' . gmdate( 'D, d M Y H:i:s', time() + 100000000 ) . ' GMT' );
+		 */
 
 		// Support for Conditional GET
 		$client_etag = isset( $_SERVER['HTTP_IF_NONE_MATCH'] ) ? stripslashes( $_SERVER['HTTP_IF_NONE_MATCH'] ) : false;

--- a/includes/class-wp-document-revisions.php
+++ b/includes/class-wp-document-revisions.php
@@ -1890,8 +1890,8 @@ class WP_Document_Revisions {
 	 * Return an empty excerpt for documents on front end views to avoid leaking
 	 * revision notes.
 	 *
-	 * @param string  $excerpt
-	 * @param WP_Post $post
+	 * @param string  $excerpt The original excerpt text associated with a post.
+	 * @param WP_Post $post    The post object.
 	 *
 	 * @return string
 	 */

--- a/includes/class-wp-document-revisions.php
+++ b/includes/class-wp-document-revisions.php
@@ -98,7 +98,7 @@ class WP_Document_Revisions {
 		add_action( 'init', array( &$this, 'edit_flow_support' ), 11 );
 		add_action( 'init', array( &$this, 'use_workflow_states' ), 50 );
 
-		// Revision comments are stored as excerpts and should not be output with the_excerpt() by default.
+		// WSU Hotfix: Revision comments are stored as excerpts and should not be output with the_excerpt() by default.
 		add_filter( 'get_the_excerpt', '__return_empty_string' );
 
 		// load front-end features (shortcode, widgets, etc.)


### PR DESCRIPTION
Revision notes are stored as excerpts on the document post type. In many default search templates, `the_excerpt()` is used to show a preview of content. When documents are part of search results, the revision notes may be accidentally made public.